### PR TITLE
fix concatenated cert/key breakage

### DIFF
--- a/files/docker-entrypoint.sh
+++ b/files/docker-entrypoint.sh
@@ -6,7 +6,7 @@ function env2cert {
     file=$1
     var="$2"
     (echo "$var" | sed 's/"//g' | grep '^-----' > /dev/null) && 
-    (echo "$var" | sed -e 's/"//g' -e 's/\r//g' | sed -e 's/- /-\n/' -e 's/ -/\n-/' | sed -e '2s/ /\n/g' > $file) && 
+    (echo "$var" | sed -e 's/"//g' -e 's/\r//g' | sed -e 's/- /-\n/g' -e 's/ -/\n-/g' | sed -e '2s/ /\n/g' > $file) && 
     echo -n $file || echo -n
 }
 


### PR DESCRIPTION
if cert/key file is concatenated multiple cert/key, env2cert formats only first cert/key, nginx cannot start with emerg error:

> nginx: [emerg] cannot load certificate "/etc/nginx/default.pem": PEM_read_bio_X509_AUX() failed (SSL: error:0908F066:PEM routines:get_header_and_data:bad end line)
